### PR TITLE
Rules csp

### DIFF
--- a/lib/utils/starter-rules.js
+++ b/lib/utils/starter-rules.js
@@ -32,8 +32,9 @@ module.exports = [
 
     halt: true,
   },
+  // content-security-policy-rules
   {
-    id:"csp-no-*",
+    id:'csp-no-*',
     header: 'content-security-policy',
     when: (headers, type) => type === 'response' && headers['content-security-policy'],
     expect: (headers) => {
@@ -47,6 +48,32 @@ module.exports = [
     pass: {
       flags: [],
     },
+  },
+  {
+    id: 'csp-script-src-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['script-src'][0] !== '*';
+    },
+    fail: {
+      message: 'Avoid setting script-src to a wild card. This allows loading scripts from any domain, any host, and on any port.',
+      flags: ['severe']
+    }
+  },
+  {
+    id: 'csp-object-src-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['object-src'][0] !== '*';
+    },
+    fail: {
+      message: 'Avoid setting object-src to a wild card. This allows loading plugins from any domain, any host, and on any port.',
+      flags: ['severe']
+    }
   },
   {
     id:"no-x-powered-by",
@@ -103,6 +130,6 @@ module.exports = [
       flags: [],
     },
     halt: false,
-  },
+  }, 
 ];
 

--- a/lib/utils/starter-rules.js
+++ b/lib/utils/starter-rules.js
@@ -76,6 +76,84 @@ module.exports = [
     }
   },
   {
+    id: 'csp-style-src-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['style-src'][0] !== '*';
+    },
+    fail: {
+      message: 'Avoid setting style-src to a wild card. This allows loading styles (CSS) from any domain, any host, and on any port.',
+      flags: []
+    }
+  },
+  {
+    id: 'csp-img-src-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['img-src'][0] !== '*';
+    },
+    fail: {
+      message: 'Avoid setting img-src to a wild card. This allows loading images from any domain or host.',
+      flags: []
+    }
+  },
+  {
+    id: 'csp-connect-src-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['connect-src'][0] !== '*';
+    },
+    fail: {
+      message: 'Avoid setting connect-src to a wild card. This allows loading connections from any domain, any host, and on any port.',
+      flags: ['severe']
+    }
+  },
+  {
+    id: 'csp-font-src-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['font-src'][0] !== '*';
+    },
+    fail: {
+      message: 'You are currently allowing fonts from any source, host, or domain.',
+      flags: []
+    }
+  },
+  {
+    id: 'csp-media-src-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['media-src'][0] !== '*';
+    },
+    fail: {
+      message: 'You are currently allowing media, such as audio or video elements, from any domain or host.',
+      flags: []
+    }
+  },
+  {
+    id: 'csp-frame-src-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['frame-src'][0] !== '*';
+    },
+    fail: {
+      message: 'Avoid setting frame-src to a wild card. This allows loading frames from any domain, any host, and on any port.',
+      flags: ['severe']
+    }
+  },
+  {
     id:"no-x-powered-by",
     header: 'x-powered-by',
     when: (_, type) => type === 'response',

--- a/lib/utils/starter-rules.js
+++ b/lib/utils/starter-rules.js
@@ -147,8 +147,60 @@ module.exports = [
       return policy['frame-src'][0] !== '*';
     },
     fail: {
-      message: 'Avoid setting frame-src to a wild card. This allows loading frames from any domain, any host, and on any port.',
+      message: 'Avoid setting frame-src to a wild card. This directive has been deprecated as of CSP level 2. Please use "child-src" instead.',
+      flags: []
+    }
+  },
+  {
+    id: 'csp-child-src-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['child-src'][0] !== '*';
+    },
+    fail: {
+      message: 'Avoid setting child-src to a wild card. This allows loading web workers and nested browsing contexts, such as <iframe>, from any domain or host.',
       flags: ['severe']
+    }
+  },
+  {
+    id: 'csp-form-action-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['form-action'][0] !== '*';
+    },
+    fail: {
+      message: 'You are currently allowing any source to be used as an HTML form action.',
+      flags: []
+    }
+  },
+  {
+    id: 'csp-frame-ancestors-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['frame-ancestors'][0] !== '*';
+    },
+    fail: {
+      message: 'Avoid setting frame-ancestors to a wild card. Setting this to "none" is roughly equivalent to using X-Frame-Options: DENY.',
+      flags: []
+    }
+  },
+  {
+    id: 'csp-plugin-types-no-*',
+    header: 'content-security-policy',
+    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    expect: (headers) => {
+      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      return policy['plugin-types'][0] !== '*';
+    },
+    fail: {
+      message: 'Avoid setting plugin-types to a wild card. This directive is used to set valid MIME types.',
+      flags: []
     }
   },
   {


### PR DESCRIPTION
* added a 'no-wildcards' rule for all the base CSP directives
### Next:
* add rules regarding all the `unsafe-inline` and `unsafe-eval` options