### PR TITLE
Rules/cleanup

### DIFF
--- a/lib/utils/parse-headers.js
+++ b/lib/utils/parse-headers.js
@@ -17,6 +17,10 @@ function contentSecurityPolicy(serialized) {
   }, {});
 }
 
+function csp(serialized) {
+  return contentSecurityPolicy(serialized);
+}
+
 function featurePolicy(serialized) {
   return serialized.split(';').reduce((policy, declaration) => {
     const tokens = declaration.trim().split(/\s+/);
@@ -31,6 +35,11 @@ function featurePolicy(serialized) {
     return policy;
   }, {});
 }
+
+function fp(serialized) {
+  return featurePolicy(serialized);
+}
+
 
 function setCookie(serialized) {
   const [nameValue, ...unparsedAttributes] = serialized.split(';');
@@ -105,7 +114,9 @@ module.exports = {
   parseHeaders,
   contentSecurityPolicy,
   cookie,
+  csp,
   featurePolicy,
-  setCookie,
+  fp,
+  setCookie
 };
 

--- a/lib/utils/starter-rules.js
+++ b/lib/utils/starter-rules.js
@@ -2,19 +2,23 @@ const {
   contentSecurityPolicy,
   cookie,
   featurePolicy,
-  setCookie,
+  setCookie
 } = require('./parse-headers');
 
 module.exports = [
   {
-    //unique id for the rule. used to deactivate in config
-    id:"include-csp",
+    // unique id for the rule. used to deactivate in config
+    id: 'include-csp',
 
     // header that the rule applies to
     header: 'content-security-policy',
 
     // callback function to determine when to check this rule
-    when: (headers, type) => type === 'response' && headers['content-type'] && headers['content-type'].indexOf('text/html') !== -1,
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-type'] &&
+      headers['content-type'].indexOf('text/html') !== -1
+    ),
 
     // callback function to determine if rule passes or fails
     expect: headers => headers['content-security-policy'],
@@ -22,17 +26,17 @@ module.exports = [
     // message and flags to set if rule fails
     fail: {
       message: 'No Content-Security-Policy in place.',
-      flags: ['severe'],
+      flags: ['severe']
     },
 
     // message and flags to set if rule passes
     pass: {
-      flags: ['csp'],
-    },
+      flags: ['csp']
+    }
   },
   // content-security-policy-rules
   {
-    id:'csp-no-*',
+    id: 'csp-no-*',
     header: 'content-security-policy',
     when: (headers, type) => type === 'response' && headers['content-security-policy'],
     expect: (headers) => {
@@ -41,16 +45,17 @@ module.exports = [
     },
     fail: {
       message: 'Avoid setting default-src to a wild card. Try opting for a stricter default and looser rules on specific sources.',
-      flags: ['severe'],
-    },
-    pass: {
-      flags: [],
-    },
+      flags: ['severe']
+    }
   },
   {
     id: 'csp-script-src-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/script-src/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['script-src'][0] !== '*';
@@ -63,7 +68,11 @@ module.exports = [
   {
     id: 'csp-object-src-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/object-src/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['object-src'][0] !== '*';
@@ -76,7 +85,11 @@ module.exports = [
   {
     id: 'csp-style-src-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/style-src/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['style-src'][0] !== '*';
@@ -89,7 +102,11 @@ module.exports = [
   {
     id: 'csp-img-src-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/img-src/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['img-src'][0] !== '*';
@@ -102,7 +119,11 @@ module.exports = [
   {
     id: 'csp-connect-src-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/connect-src/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['connect-src'][0] !== '*';
@@ -115,7 +136,11 @@ module.exports = [
   {
     id: 'csp-font-src-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/font-src/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['font-src'][0] !== '*';
@@ -128,7 +153,11 @@ module.exports = [
   {
     id: 'csp-media-src-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/media-src/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['media-src'][0] !== '*';
@@ -141,7 +170,11 @@ module.exports = [
   {
     id: 'csp-frame-src-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/frame-src/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['frame-src'][0] !== '*';
@@ -154,7 +187,11 @@ module.exports = [
   {
     id: 'csp-child-src-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/child-src/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['child-src'][0] !== '*';
@@ -167,7 +204,11 @@ module.exports = [
   {
     id: 'csp-form-action-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/form-action/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['form-action'][0] !== '*';
@@ -180,7 +221,11 @@ module.exports = [
   {
     id: 'csp-frame-ancestors-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/frame-ancestors/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['frame-ancestors'][0] !== '*';
@@ -193,7 +238,11 @@ module.exports = [
   {
     id: 'csp-plugin-types-no-*',
     header: 'content-security-policy',
-    when: (headers, type) => type === 'response' && headers['content-security-policy'],
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-security-policy'] &&
+      headers['content-security-policy'].match(/plugin-types/)
+    ),
     expect: (headers) => {
       const policy = contentSecurityPolicy(headers['content-security-policy']);
       return policy['plugin-types'][0] !== '*';
@@ -204,56 +253,51 @@ module.exports = [
     }
   },
   {
-    id:"no-x-powered-by",
+    id: 'no-x-powered-by',
     header: 'x-powered-by',
-    when: (_, type) => type === 'response',
+    when: (headers, type) => type === 'response',
     expect: headers => !headers['x-powered-by'],
     fail: {
       message: 'The X-Powered-By header advertises unnecessary details about your server, and should not be sent.',
-      flags: ['severe'],
-    },
-    pass: {
       flags: [],
     },
   },
   {
-    id:"include-nosniff",
+    id: 'include-nosniff',
     header: 'x-content-type-options',
-    when: (_, type) => type === 'response',
+    when: (headers, type) => type === 'response',
     expect: headers => headers['x-content-type'] === 'nosniff',
     fail: {
       message: 'X-Content-Type-Options should be present on all responses, with a value of nosniff.',
-      flags: ['severe'],
-    },
-    pass: {
-      flags: [],
-    },
+      flags: ['severe']
+    }
   },
   {
-    id:"include-fp",
+    id: 'include-fp',
     header: 'feature-policy',
-    when: (headers, type) => type === 'response' && headers['content-type'] && headers['content-type'].indexOf('text/html') !== -1,
+    when: (headers, type) => (
+      type === 'response' &&
+      headers['content-type'] &&
+      headers['content-type'].indexOf('text/html') !== -1
+    ),
     expect: headers => headers['feature-policy'],
     fail: {
       message: 'Consider setting a Feature-Policy header on HTML files, to restrict device access to necessary features.',
-      flags: ['severe'],
+      flags: ['severe']
     },
     pass: {
-      flags: ['fp'],
-    },
+      flags: ['fp']
+    }
   },
   {
-    id:"include-x-xss-protection",
+    id: 'include-x-xss-protection',
     header: 'x-xss-protection',
     when: (headers, type) => type === 'response' && headers['content-type'] && headers['content-type'].indexOf('text/html') !== -1,
     expect: headers => headers['x-xss-protection'] !== 0,
     fail: {
       message: 'While you may not need stricter XSS protection policies, there is rarely a good reason to deactivate the browser\'s default protections.',
-      flags: ['severe'],
-    },
-    pass: {
-      flags: [],
-    },
-  },
+      flags: ['severe']
+    }
+  }
 ];
 

--- a/lib/utils/starter-rules.js
+++ b/lib/utils/starter-rules.js
@@ -1,7 +1,7 @@
 const {
-  contentSecurityPolicy,
+  csp,
   cookie,
-  featurePolicy,
+  fp,
   setCookie
 } = require('./parse-headers');
 
@@ -40,7 +40,7 @@ module.exports = [
     header: 'content-security-policy',
     when: (headers, type) => type === 'response' && headers['content-security-policy'],
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['default-src'][0] !== '*';
     },
     fail: {
@@ -57,7 +57,7 @@ module.exports = [
       headers['content-security-policy'].match(/script-src/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['script-src'][0] !== '*';
     },
     fail: {
@@ -74,7 +74,7 @@ module.exports = [
       headers['content-security-policy'].match(/object-src/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['object-src'][0] !== '*';
     },
     fail: {
@@ -91,7 +91,7 @@ module.exports = [
       headers['content-security-policy'].match(/style-src/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['style-src'][0] !== '*';
     },
     fail: {
@@ -108,7 +108,7 @@ module.exports = [
       headers['content-security-policy'].match(/img-src/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['img-src'][0] !== '*';
     },
     fail: {
@@ -125,7 +125,7 @@ module.exports = [
       headers['content-security-policy'].match(/connect-src/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['connect-src'][0] !== '*';
     },
     fail: {
@@ -142,7 +142,7 @@ module.exports = [
       headers['content-security-policy'].match(/font-src/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['font-src'][0] !== '*';
     },
     fail: {
@@ -159,7 +159,7 @@ module.exports = [
       headers['content-security-policy'].match(/media-src/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['media-src'][0] !== '*';
     },
     fail: {
@@ -176,7 +176,7 @@ module.exports = [
       headers['content-security-policy'].match(/frame-src/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['frame-src'][0] !== '*';
     },
     fail: {
@@ -193,7 +193,7 @@ module.exports = [
       headers['content-security-policy'].match(/child-src/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['child-src'][0] !== '*';
     },
     fail: {
@@ -210,7 +210,7 @@ module.exports = [
       headers['content-security-policy'].match(/form-action/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['form-action'][0] !== '*';
     },
     fail: {
@@ -227,7 +227,7 @@ module.exports = [
       headers['content-security-policy'].match(/frame-ancestors/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['frame-ancestors'][0] !== '*';
     },
     fail: {
@@ -244,7 +244,7 @@ module.exports = [
       headers['content-security-policy'].match(/plugin-types/)
     ),
     expect: (headers) => {
-      const policy = contentSecurityPolicy(headers['content-security-policy']);
+      const policy = csp(headers['content-security-policy']);
       return policy['plugin-types'][0] !== '*';
     },
     fail: {


### PR DESCRIPTION
No guarantees that certain properties exist on given objects, plus lines were getting a little long, so most of the rule "when" checks have been cleaned up for legibility.
Added aliases for `contentSecurityPolicy` and `featurePolicy` parsers (`csp` and `fp`, respectively)
*Note the attempt to avoid trailing commas. If our backend has no trailing commas we support back to Node 6.4 or so; with trailing commas we only support back to somewhere in Node 8