### PR TITLE
🐛 change apply-rule logic to not fail on rules without pass settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ Get your headers in order _before_ deployment.
 ## Demo
 
 This repository has a built-in brom config, so just clone, install, and
-run to see brom in action.
+run to see brom in action. You'll need Node 6.4.0 or later, and npm.
 
 1. Clone this repository locally
-2. `npm install`
-3. `brom` (you'll need to install this globally, or on Unix-y systems you
-   can simply run `lib/index.js`)
+2. In the root directory, `npm install`
+3. `npm install -g brom`
+4. `brom`
+5. brom will open the GUI in your default browser automatically. Open
+   a second tab and navigate to localhost:9999 to start making/recording
+   requests.
 
 ## Usage
 

--- a/lib/utils/apply-rules.js
+++ b/lib/utils/apply-rules.js
@@ -55,7 +55,7 @@ module.exports = function applyRules(transaction, type) {
         if (rule.pass.message) {
           output.warnings[header] = smartConcat(output.warnings[header], `${id}: ${rule.pass.message}`);
         }
-      } else {
+      } else if (!pass) {
         // add all associated flags to the flags output
         if (rule.fail.flags) {
           output.flags = [...new Set(output.flags.concat(rule.fail.flags))];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brom",
-  "version": "0.1.9",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Rules that don't have `pass` settings were failing by default. Updated the
main logic in apply-rules to just skip over passing cases that don't
have them.